### PR TITLE
Adicionar testes para busca de produto

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 Sistema desenvolvido para apoiar turmas na construção de habilidades essenciais para a operação de caixa e o atendimento ao cliente. Por meio de simulações de vendas, oferece suporte à imersão em ambientes e situações reais de trabalho, proporcionando uma experiência prática e eficaz.
+
+## Testes
+
+Este projeto utiliza [PHPUnit](https://phpunit.de/) para os testes.
+
+1. Instale as dependências:
+   ```bash
+   composer install
+   ```
+2. Execute os testes:
+   ```bash
+   vendor/bin/phpunit
+   ```
+
+Os testes usam mocks de banco de dados para garantir isolamento e não exigem uma instância real de MySQL.

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,8 @@
+{
+    "name": "senacmart/app",
+    "description": "Sistema de simulação de supermercado",
+    "require": {},
+    "require-dev": {
+        "phpunit/phpunit": "^10.5"
+    }
+}

--- a/tests/BuscarProdutoTest.php
+++ b/tests/BuscarProdutoTest.php
@@ -1,0 +1,46 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class BuscarProdutoTest extends TestCase
+{
+    private $originalIncludePath;
+
+    protected function setUp(): void
+    {
+        $this->originalIncludePath = get_include_path();
+        set_include_path(__DIR__);
+    }
+
+    protected function tearDown(): void
+    {
+        set_include_path($this->originalIncludePath);
+        unset($_GET['busca'], $GLOBALS['__TEST_PRODUCT__']);
+    }
+
+    private function executarScript(): array
+    {
+        ob_start();
+        include __DIR__ . '/../buscar_produto.php';
+        return json_decode(ob_get_clean(), true);
+    }
+
+    public function testRetornaDadosJsonParaCodigoExistente(): void
+    {
+        $produto = ['codigo' => '123', 'nome' => 'Produto Teste'];
+        $GLOBALS['__TEST_PRODUCT__'] = $produto;
+        $_GET['busca'] = '123';
+
+        $dados = $this->executarScript();
+        $this->assertSame($produto, $dados);
+    }
+
+    public function testRetornaErroQuandoProdutoNaoEncontrado(): void
+    {
+        $GLOBALS['__TEST_PRODUCT__'] = null;
+        $_GET['busca'] = '999';
+
+        $dados = $this->executarScript();
+        $this->assertSame('Produto não encontrado.', $dados['erro']);
+    }
+}
+

--- a/tests/conexao.php
+++ b/tests/conexao.php
@@ -1,0 +1,22 @@
+<?php
+if (!class_exists('StubResult')) {
+    class StubResult {
+        private $row;
+        public function __construct($row) { $this->row = $row; }
+        public function fetch_assoc() { return $this->row; }
+    }
+    class StubStatement {
+        private $row;
+        public function __construct($row) { $this->row = $row; }
+        public function bind_param($types, &...$vars) {}
+        public function execute() {}
+        public function get_result() { return new StubResult($this->row); }
+    }
+    class StubConnection {
+        private $row;
+        public function __construct($row) { $this->row = $row; }
+        public function prepare($sql) { return new StubStatement($this->row); }
+    }
+}
+$conn = new StubConnection($GLOBALS['__TEST_PRODUCT__'] ?? null);
+


### PR DESCRIPTION
## Summary
- add PHPUnit tests for product lookup success and failure
- mock database connection for isolated testing
- document test execution in README

## Testing
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a476506bbc8321b385739c9d687eac